### PR TITLE
Fix compile error

### DIFF
--- a/svm/Makefile
+++ b/svm/Makefile
@@ -10,11 +10,10 @@ all: $(TARGET)
 
 $(TARGET): $(OBJS) $(MEMORY)
 	make -C ../memory
-	$(CC) -lm -o $@ $^
+	$(CC) -o $@ $^ -lm
 
 .c.o:
 	$(CC) $(CFLAGS) $*.c
 
 clean:
 	rm -rf $(TARGET) *.o *~ disasm svm
-


### PR DESCRIPTION
svmディレクトリのMakefileで、-lmオプションを末尾に移動させることでコンパイルエラーを修正した。